### PR TITLE
Fix vercel function runtime version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "bayesian-forward-operator",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=18.17.0"
+  },
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,7 @@
 {
+  "version": 2,
   "buildCommand": "npm run build",
   "outputDirectory": ".next",
   "framework": "nextjs",
-  "regions": ["iad1"],
-  "functions": {
-    "app/**/*.{js,ts,tsx}": {
-      "runtime": "nodejs18.x"
-    }
-  }
+  "regions": ["iad1"]
 }


### PR DESCRIPTION
Fix Vercel deployment error by simplifying `vercel.json` and specifying Node.js engine.

The previous `vercel.json` contained an incorrect and unnecessary `functions` configuration, which caused Vercel to fail deployment with the error `Function Runtimes must have a valid version`. For Next.js applications, Vercel typically auto-detects the runtime, making explicit function configurations redundant. This PR removes the problematic section and adds the required Vercel config version, along with Node.js engine consistency in `package.json`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f4f5ed2-ef8d-4b5c-be46-c1c63501b215">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5f4f5ed2-ef8d-4b5c-be46-c1c63501b215">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

