### PR TITLE
Debug map tile and react errors

### DIFF
--- a/components/MapScene.tsx
+++ b/components/MapScene.tsx
@@ -434,26 +434,17 @@ function MapScene({
       minZoom: 0,
       maxZoom: 23,
       strategy: 'no-overlap',
-      // Try external elevation data first, with procedural fallback
-      elevationData: process.env.NODE_ENV === 'development' 
-        ? createHeightMapDataURL(proceduralTerrain, bounds)
-        : 'https://elevation-tiles-prod.s3.amazonaws.com/terrarium/{z}/{x}/{y}.png',
+      // Use procedural terrain for now since external elevation tiles are not available
+      elevationData: createHeightMapDataURL(proceduralTerrain, bounds),
       texture: showLabels 
         ? 'https://tile.opentopomap.org/{z}/{x}/{y}.png'
         : undefined,
-      elevationDecoder: process.env.NODE_ENV === 'development'
-        ? {
-            rScaler: 1,
-            gScaler: 1,
-            bScaler: 1,
-            offset: 0
-          }
-        : {
-            rScaler: 256,
-            gScaler: 1,
-            bScaler: 1 / 256,
-            offset: -32768
-          },
+      elevationDecoder: {
+        rScaler: 1,
+        gScaler: 1,
+        bScaler: 1,
+        offset: 0
+      },
       color: showLabels ? [255, 255, 255] : [40, 60, 80], // Tactical tint when no labels
       opacity: 0.8,
       wireframe: false
@@ -761,11 +752,6 @@ function MapScene({
       >
         <ReactMapGL
           {...viewState}
-          onMove={(evt) => setViewState({
-            ...evt.viewState,
-            minZoom: viewState.minZoom,
-            maxZoom: viewState.maxZoom
-          })}
           mapStyle="https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
           style={{ width: '100%', height: '100%' }}
         />

--- a/docs/ASSET_PLACEHOLDERS.md
+++ b/docs/ASSET_PLACEHOLDERS.md
@@ -97,12 +97,10 @@ const heightMapURL = createHeightMapDataURL(terrain, bounds);
 
 ### 4. MapScene Integration (`/components/MapScene.tsx`)
 
-**Conditional Asset Loading**:
+**Procedural Asset Loading**:
 ```typescript
-// Development mode uses procedural assets
-elevationData: process.env.NODE_ENV === 'development' 
-  ? createHeightMapDataURL(proceduralTerrain, bounds)
-  : 'https://elevation-tiles-prod.s3.amazonaws.com/terrarium/{z}/{x}/{y}.png'
+// Using procedural terrain generation for elevation data
+elevationData: createHeightMapDataURL(proceduralTerrain, bounds)
 ```
 
 **Fallback Infrastructure**:


### PR DESCRIPTION
Fixes React infinite loop and 404 elevation tile errors by removing conflicting view state handler and switching to always use procedural terrain.

The React error #185 was caused by an infinite loop due to `ReactMapGL`'s `onMove` handler conflicting with `DeckGL`'s `onViewStateChange` when both were trying to manage the same `viewState`. The 404 errors for elevation tiles occurred because the application was attempting to load terrain data from a non-existent AWS S3 bucket in production. This PR resolves both by streamlining view state management and ensuring procedural terrain is always used.

---
<a href="https://cursor.com/background-agent?bcId=bc-09f047b1-7ca8-438f-b643-80aec66d9c00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09f047b1-7ca8-438f-b643-80aec66d9c00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

